### PR TITLE
Add dependency on ocaml

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -15,5 +15,6 @@
 Projects that want to use the Either module defined in OCaml 4.12.0 while
 staying compatible with older versions of OCaml should use this library
 instead.
-"))
+")
+ (depends ocaml))
 

--- a/either.opam
+++ b/either.opam
@@ -14,6 +14,7 @@ doc: "https://mirage.github.io/either"
 bug-reports: "https://github.com/mirage/either/issues"
 depends: [
   "dune" {>= "2.0"}
+  "ocaml"
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
The dune executable doesn't assume that an ocaml compiler is installed, so packages that build with dune and need an ocaml compiler must depend on the `ocaml` package. This hasn't really caused any problems until recently since the `dune` package depends on the `ocaml` package, but the new work on dune package management makes it possible for dune to be installed without an ocaml compiler. In this environment, packages written in ocaml that build with dune must explicitly depend on the compiler.